### PR TITLE
ランキング一覧と暗合通貨詳細ページに表示する内容を調整

### DIFF
--- a/app/src/components/Card.astro
+++ b/app/src/components/Card.astro
@@ -1,10 +1,12 @@
 ---
+import LegalCurrencyUtil from '../utils/LegalCurrencyUtil';
+
 export interface Props {
 	digitalCurrency: {
 		name: string;
 		rank: number;
 		price: number;
-		marketCap: string;
+		marketCap: number;
 	}
 }
 
@@ -15,8 +17,10 @@ const { name, rank, price, marketCap } = Astro.props.digitalCurrency;
 	<div>
 		<h2>{name}</h2>
 		<p>Rank: {rank}</p>
-		<p>Price: {price}</p>
-		<p>MarketCap: {marketCap}</p>
+		<p>Price: {LegalCurrencyUtil.format(price, 'USD')}</p>
+		<p>MarketCap: {LegalCurrencyUtil.format(marketCap, 'USD')}</p>
+		<p>Price(JPY): {LegalCurrencyUtil.format(price, 'JPY')}</p>
+		<p>MarketCap(JPY): {LegalCurrencyUtil.format(marketCap, 'JPY')}</p>
 	</div>
 </li>
 <style>

--- a/app/src/components/LinkCard.astro
+++ b/app/src/components/LinkCard.astro
@@ -1,26 +1,21 @@
 ---
 export interface Props {
-	digitalCurrency: {
-		name: string;
-		rank: number;
-		price: number;
-		marketCap: string;
-	}
+	href: string;
+	name: string;
+	marketCap: number;
 }
 
-const { name, rank, price, marketCap } = Astro.props.digitalCurrency;
+const { href, name, marketCap } = Astro.props;
 ---
 
-<li class="card">
-	<div>
+<li class="link-card">
+	<a href={href}>
 		<h2>{name}</h2>
-		<p>Rank: {rank}</p>
-		<p>Price: {price}</p>
 		<p>MarketCap: {marketCap}</p>
-	</div>
+	</a>
 </li>
 <style>
-	.card {
+	.link-card {
 		list-style: none;
 		display: flex;
 		padding: 0.25rem;
@@ -33,7 +28,7 @@ const { name, rank, price, marketCap } = Astro.props.digitalCurrency;
 		box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
 	}
 
-	.card > div {
+	.link-card > a {
 		width: 100%;
 		text-decoration: none;
 		line-height: 1.4;
@@ -52,5 +47,12 @@ const { name, rank, price, marketCap } = Astro.props.digitalCurrency;
 		margin-top: 0.5rem;
 		margin-bottom: 0;
 		color: #444;
+	}
+	.link-card:is(:hover, :focus-within) {
+		background-position: 0;
+		background-image: var(--accent-gradient);
+	}
+	.link-card:is(:hover, :focus-within) h2 {
+		color: rgb(var(--accent));
 	}
 </style>

--- a/app/src/components/LinkCard.astro
+++ b/app/src/components/LinkCard.astro
@@ -1,4 +1,6 @@
 ---
+import LegalCurrencyUtil from '../utils/LegalCurrencyUtil';
+
 export interface Props {
 	href: string;
 	name: string;
@@ -11,7 +13,7 @@ const { href, name, marketCap } = Astro.props;
 <li class="link-card">
 	<a href={href}>
 		<h2>{name}</h2>
-		<p>MarketCap: {marketCap}</p>
+		<p>MarketCap: {LegalCurrencyUtil.format(marketCap, 'USD')}</p>
 	</a>
 </li>
 <style>

--- a/app/src/pages/[symbol].astro
+++ b/app/src/pages/[symbol].astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Card from '../components/Card.astro';
 import { fetchDigitalCurrencyRankings, DigitalCurrencyRankings } from '../apis/fetchDigitalCurrencyRankings';
 
-export async function getStaticPaths({}) {
+export async function getStaticPaths() {
 	const digitalCurrencyRankings = await fetchDigitalCurrencyRankings();
 	
 	return digitalCurrencyRankings.data.map((digitalCurrency: DigitalCurrencyRankings) => {
@@ -20,13 +20,7 @@ const { digitalCurrency } = Astro.props
 <Layout title="DCI detail">
 	<main>
 		<h1><span class="text-gradient">About { digitalCurrency.name}</span></h1>
-		<Card
-			href={''}
-			name={digitalCurrency.name}
-			rank={digitalCurrency.rank}
-			price={digitalCurrency.price}
-			marketCap={digitalCurrency.marketCap}
-		/>
+		<Card digitalCurrency={digitalCurrency} />
 	</main>
 </Layout>
 

--- a/app/src/pages/index.astro
+++ b/app/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import Card from '../components/Card.astro';
+import LinkCard from '../components/LinkCard.astro';
 import { fetchDigitalCurrencyRankings, DigitalCurrencyRankings } from '../apis/fetchDigitalCurrencyRankings';
 
 const digitalCurrencyRankings = await fetchDigitalCurrencyRankings();
@@ -12,11 +12,10 @@ const digitalCurrencyRankings = await fetchDigitalCurrencyRankings();
 		<ul role="list" class="link-card-grid">
 			{
 				digitalCurrencyRankings.data.map((digitalCurrency: DigitalCurrencyRankings) => (
-					<Card
+					<LinkCard
 						href={`/${digitalCurrency.symbol.toLowerCase()}/`}
 						name={digitalCurrency.name}
-						rank={digitalCurrency.rank}
-						price={digitalCurrency.price}
+						marketCap={digitalCurrency.marketCap}
 					/>
 				))
 			}

--- a/app/src/utils/LegalCurrencyUtil.ts
+++ b/app/src/utils/LegalCurrencyUtil.ts
@@ -1,0 +1,28 @@
+export default class LegalCurrencyUtil {
+    private static readonly locales: { [key: string]: { locale: string; currency: string } } = {
+        JPY: {
+            locale: 'ja-JP',
+            currency: 'JPY'
+        },
+        USD: {
+            locale: 'us-EN',
+            currency: 'USD'
+        },
+    }
+
+    /**
+     * 指定した法定通貨表示にフォーマットする
+     * 
+     * @param number 
+     * @param locale 
+     * @returns 
+     */
+    static format (number: number, locale: 'JPY' | 'USD'): string {
+        const formatter = new Intl.NumberFormat(this.locales[locale].locale, {
+            style: 'currency',
+            currency: this.locales[locale].currency
+        });
+
+        return formatter.format(number);
+    }
+}


### PR DESCRIPTION
## 概要
#7 

## 対応内容
 - 一覧と詳細ページでコンポーネントを分けた
 - 法定通貨ユーティリティクラスを作成して価格表示をフォーマットできるように実装

## 備考
 - 表示形式をフォーマットしているだけで、為替レートなどは考慮したいないので ドルから円への変換が必要